### PR TITLE
Tracing sampling fixed

### DIFF
--- a/django_py_zipkin/tests/test_middleware.py
+++ b/django_py_zipkin/tests/test_middleware.py
@@ -87,7 +87,6 @@ class ZipkinMiddlewareTest(TestCase):
         self.assertEqual(response.zipkin_is_tracing, True)
         patched_random.assert_called_once()
 
-
     @override_settings(
         ZIPKIN_TRACING_ENABLED=True,
         ZIPKIN_HTTP_ENDPOINT='http://127.0.0.1:9411/api/v1/spans',


### PR DESCRIPTION
Every call of `is_tracing` method may return a new value if tracing is enabled and request not contains 'HTTP_X_B3_SAMPLED' header.
`process_request` method checks if request is tracing and if it is True calls `add_zipkin_to_request`, which calls `is_tracing` again.
In case if `is_tracing` returns True for the first call and False for the second call, py_zipkin will raise error.